### PR TITLE
Implement calling conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,22 @@ Successfully passes all [test cases](https://github.com/nlsandler/write_a_c_comp
 - Conditionals (if/else, Ternary "?:")
 - Compound Statements / Code Blocks / Scopes
 - Loops (for, do, while)
-- Function Declaration and Definition (returning int value, optional arguments), Calling
+- Function Declaration, Definition and Calling (returning int value, optional arguments)
 
 ### Not (yet) implemented:
-Optionally from [Part5](https://norasandler.com/2018/01/08/Write-a-Compiler-5.html):
-- Compound Assignment Operators ("+=", "-=", "/=", "*=", "%=", "<<=", ">>=", "&=", "|=", "^=")
-- Comma Operator (e1, e2)
-- Increment/Decrement Operators (Prefix and postfix ++, Prefix and postfix --)
+- Optionally from [Part5](https://norasandler.com/2018/01/08/Write-a-Compiler-5.html):
+  - Compound Assignment Operators ("+=", "-=", "/=", "*=", "%=", "<<=", ">>=", "&=", "|=", "^=")
+  - Comma Operator (e1, e2)
+  - Increment/Decrement Operators (Prefix and postfix ++, Prefix and postfix --)
 
-Correct* usage of [Calling Conventions for x86_64](https://en.wikipedia.org/wiki/X86_calling_conventions) (System V ABI for Linux 64-Bit and others, or MS x64 ABI for Windows 64-Bit) and [Calling Conventions for Arm64](https://en.wikipedia.org/wiki/Calling_convention#ARM_(A64))
-
-\* The first n arguments are now passed via the correct registers (n depending on Calling Convention), 
-the rest are put on the stack (but reading them is not yet implemented)
+- Optimizations (Constant folding, Constant propagation, Dead code elimination, etc.)
 
 ### Other notes:
 - Compiles source into x86_64 or Arm64 assembly (depends on OS arch)
 - Generated *.s files get assembled using gcc
 - There is an option to interpret a source file (for supported subset)
 - Running Tests removes output files
+- Uses [Calling Conventions for x86_64](https://en.wikipedia.org/wiki/X86_calling_conventions) (System V ABI for Linux 64-Bit and others, or MS x64 ABI for Windows 64-Bit) and [Calling Conventions for Arm64](https://en.wikipedia.org/wiki/Calling_convention#ARM_(A64))
 
 ## Tested on
 - Windows 10 64-Bit (Visual Studio 2022, .Net 6.0, gcc installed via cygwin 3.3.5)

--- a/mcc/ArmGenerator.cs
+++ b/mcc/ArmGenerator.cs
@@ -81,13 +81,20 @@ namespace mcc
                 ArmInstruction($"ldr {argRegister4B[i]}, [sp, #{i * pointerSize}]");
             }
 
-            // deallocate memory for args in registers
-            ArmInstruction("add sp, sp, #" + Math.Min(funCall.Arguments.Count, argRegister4B.Length) * pointerSize);
+            // deallocate memory for args in registers, only in pairs of two to maintain stack alignment
+            if (Math.Min(funCall.Arguments.Count, argRegister4B.Length) % 2 == 0)
+            {
+                ArmInstruction("add sp, sp, #" + Math.Min(funCall.Arguments.Count, argRegister4B.Length) * pointerSize);
+            }
 
             CallFunction(funCall.Name);
 
             // deallocate memory for args not in registers
             int deallocate = allocate - Math.Min(funCall.Arguments.Count, argRegister4B.Length) * pointerSize;
+            if (Math.Min(funCall.Arguments.Count, argRegister4B.Length) % 2 != 0)
+            {
+                deallocate = allocate;
+            }
             ArmInstruction("add sp, sp, #" + deallocate);
             //DeallocateMemory(funCall.BytesToDeallocate);
         }

--- a/mcc/ArmGenerator.cs
+++ b/mcc/ArmGenerator.cs
@@ -64,39 +64,40 @@ namespace mcc
             const int pointerSize = 8;
 
             // allocate space for arguments, 16 byte aligned
-            int allocate = 16 * ((funCall.Arguments.Count * pointerSize + 15) / 16);
+            int allocate = 16 * (((funCall.Arguments.Count * pointerSize) + 15) / 16);
             ArmInstruction("sub sp, sp, #" + allocate);
 
             // move arguments beginning at last argument, up the stack beginning at stack pointer into temp storage
             for (int i = funCall.Arguments.Count - 1; i >= 0; i--)
             {
                 Generate(funCall.Arguments[i]);
-                //ArmInstruction("str w0, [sp, #-16]!");   // push 16 bytes, needs to be 16 byte aligned
                 ArmInstruction($"str w0, [sp, #{i * pointerSize}]");
             }
 
+            int regsUsed = Math.Min(funCall.Arguments.Count, argRegister4B.Length);
+
             // move arguments into registers
-            for (int i = 0; i < Math.Min(funCall.Arguments.Count, argRegister4B.Length); i++)
+            for (int i = 0; i < regsUsed; i++)
             {
                 ArmInstruction($"ldr {argRegister4B[i]}, [sp, #{i * pointerSize}]");
             }
 
             // deallocate memory for args in registers, only in pairs of two to maintain stack alignment
-            if (Math.Min(funCall.Arguments.Count, argRegister4B.Length) % 2 == 0)
+            if (regsUsed % 2 == 0)
             {
-                ArmInstruction("add sp, sp, #" + Math.Min(funCall.Arguments.Count, argRegister4B.Length) * pointerSize);
+                ArmInstruction("add sp, sp, #" + (regsUsed * pointerSize));
             }
 
             CallFunction(funCall.Name);
 
             // deallocate memory for args not in registers
-            int deallocate = allocate - Math.Min(funCall.Arguments.Count, argRegister4B.Length) * pointerSize;
-            if (Math.Min(funCall.Arguments.Count, argRegister4B.Length) % 2 != 0)
+            int deallocate = allocate - (regsUsed * pointerSize);
+            // if we didnt deallocate parts of the memory, do it all here
+            if (regsUsed % 2 != 0)
             {
                 deallocate = allocate;
             }
             ArmInstruction("add sp, sp, #" + deallocate);
-            //DeallocateMemory(funCall.BytesToDeallocate);
         }
 
         private void GenerateContinue(ASTContinueNode con)

--- a/mcc/ArmGenerator.cs
+++ b/mcc/ArmGenerator.cs
@@ -87,7 +87,7 @@ namespace mcc
             CallFunction(funCall.Name);
 
             // deallocate memory for args not in registers
-            int deallocate = (funCall.Arguments.Count - Math.Min(funCall.Arguments.Count, argRegister4B.Length)) * pointerSize;
+            int deallocate = allocate - Math.Min(funCall.Arguments.Count, argRegister4B.Length) * pointerSize;
             ArmInstruction("add sp, sp, #" + deallocate);
             //DeallocateMemory(funCall.BytesToDeallocate);
         }

--- a/mcc/ArmGenerator.cs
+++ b/mcc/ArmGenerator.cs
@@ -67,6 +67,7 @@ namespace mcc
                 ArmInstruction("str w0, [sp, #-16]!");   // push 16 bytes, needs to be 16 byte aligned
             }
 
+            // note3.5: make sure stack stays aligned by subbing 8 bytes if excess args is odd
             // todo: only works for first 8 arguments, rest is on stack (needs stack calculations)
             for (int i = 0; i < Math.Min(funCall.Arguments.Count, argRegister4B.Length); i++)
             {
@@ -74,7 +75,7 @@ namespace mcc
             }
 
             CallFunction(funCall.Name);
-            //DeallocateMemory(funCall.BytesToDeallocate);
+            DeallocateMemory(funCall.BytesToDeallocate);
         }
 
         private void GenerateContinue(ASTContinueNode con)
@@ -311,6 +312,7 @@ namespace mcc
         private void GenerateReturn(ASTReturnNode ret)
         {
             Generate(ret.Expression);
+            // todo: jump to epilogue, do not generate epilogue multiple times
             FunctionEpilogue();
         }
 

--- a/mcc/Generator.cs
+++ b/mcc/Generator.cs
@@ -107,7 +107,7 @@ namespace mcc
             CallFunction(funCall.Name);
 
             // deallocate is allocate minus the ones which were popped into registers
-            int deallocate = allocate - (argRegs.Length * pointerSize);
+            int deallocate = allocate - (Math.Min(funCall.Arguments.Count, argRegs.Length) * pointerSize);
             if (OperatingSystem.IsWindows())
             {
                 // on windows we need to deallocate the shadow space as well, where we moved args but didnt pop them

--- a/mcc/Generator.cs
+++ b/mcc/Generator.cs
@@ -106,6 +106,11 @@ namespace mcc
                 }
             }
 
+            if (OperatingSystem.IsWindows())
+            {
+                Instruction("subq $32, %rsp");  // shadow space
+            }
+
             CallFunction(funCall.Name);
             // baseoffset (shadow space on windows) + n arguments not in registers + padding (isodd)
             funCall.BytesToDeallocate = Math.Max(funCall.Arguments.Count - argsInRegisters + (isOdd ? 1 : 0), 0) * 8 + baseOffset;
@@ -477,14 +482,14 @@ namespace mcc
 
         private void PushLeftOperand()
         {
-            Instruction("push %rax");
+            Instruction("pushq %rax");
             pushCounter++;
         }
 
         private void PopLeftOperand()
         {
             Instruction("movl %eax, %ecx"); // need to switch src and dest for - and /
-            Instruction("pop %rax");
+            Instruction("popq %rax");
             pushCounter--;
         }
 

--- a/mcc/Generator.cs
+++ b/mcc/Generator.cs
@@ -72,6 +72,13 @@ namespace mcc
                 // stack pointer is not aligned (due to binOp), add padding
                 allocate += pointerSize;
             }
+
+            // make sure we allocate at least enough for shadow space on windows
+            if (OperatingSystem.IsWindows())
+            {
+                allocate = Math.Max(allocate, 4 * pointerSize);
+            }
+
             Instruction($"subq ${allocate}, %rsp");
 
             // move arguments beginning at last argument, up the stack beginning at stack pointer into temp storage

--- a/mcc/Generator.cs
+++ b/mcc/Generator.cs
@@ -66,7 +66,7 @@ namespace mcc
             const int pointerSize = 8;
 
             // allocate space for arguments, 16 byte aligned
-            int allocate = 16 * ((funCall.Arguments.Count * pointerSize + 15) / 16);
+            int allocate = 16 * (((funCall.Arguments.Count * pointerSize) + 15) / 16);
             if (pushCounter % 2 != 0)
             {
                 // stack pointer is not aligned (due to binOp), add padding
@@ -89,9 +89,10 @@ namespace mcc
             }
 
             string[] argRegs = OperatingSystem.IsLinux() ? argRegister8B : argRegisterWin8B;
+            int regsUsed = Math.Min(funCall.Arguments.Count, argRegs.Length);
 
             // pop arguments into registers, rest should be then at the stack pointer
-            for (int i = 0; i < Math.Min(funCall.Arguments.Count, argRegs.Length); i++)
+            for (int i = 0; i < regsUsed; i++)
             {
                 if (OperatingSystem.IsWindows())
                 {
@@ -107,7 +108,7 @@ namespace mcc
             CallFunction(funCall.Name);
 
             // deallocate is allocate minus the ones which were popped into registers
-            int deallocate = allocate - (Math.Min(funCall.Arguments.Count, argRegs.Length) * pointerSize);
+            int deallocate = allocate - (regsUsed * pointerSize);
             if (OperatingSystem.IsWindows())
             {
                 // on windows we need to deallocate the shadow space as well, where we moved args but didnt pop them

--- a/mcc/Program.cs
+++ b/mcc/Program.cs
@@ -333,10 +333,14 @@ namespace mcc
                 ArmGenerator generator = new ArmGenerator(program);
                 return generator.GenerateARM();
             }
-            else
+            else if (System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X64)
             {
                 Generator generator = new Generator(program);
                 return generator.GenerateX86();
+            }
+            else
+            {
+                return "";
             }
         }
 

--- a/mcc/Properties/launchSettings.json
+++ b/mcc/Properties/launchSettings.json
@@ -6,7 +6,7 @@
     },
     "debug": {
       "commandName": "Project",
-      "commandLineArgs": "-d misc\\valid\\many_args.c",
+      "commandLineArgs": "-d misc\\valid\\many_args4.c",
       "workingDirectory": "C:\\Users\\Manuel\\OneDrive\\Development\\mcc\\mcc\\Test"
     },
     "test": {
@@ -72,6 +72,11 @@
     "comments": {
       "commandName": "Project",
       "commandLineArgs": "-t comments",
+      "workingDirectory": "C:\\Users\\Manuel\\OneDrive\\Development\\mcc\\mcc\\Test"
+    },
+    "misc": {
+      "commandName": "Project",
+      "commandLineArgs": "-t misc",
       "workingDirectory": "C:\\Users\\Manuel\\OneDrive\\Development\\mcc\\mcc\\Test"
     }
   }

--- a/mcc/Properties/launchSettings.json
+++ b/mcc/Properties/launchSettings.json
@@ -6,12 +6,12 @@
     },
     "debug": {
       "commandName": "Project",
-      "commandLineArgs": "-d comments\\invalid\\missing_ending.c",
+      "commandLineArgs": "-d misc\\valid\\many_args.c",
       "workingDirectory": "C:\\Users\\Manuel\\OneDrive\\Development\\mcc\\mcc\\Test"
     },
     "test": {
       "commandName": "Project",
-      "commandLineArgs": "-t stage_9\\valid\\mutual_recursion.c",
+      "commandLineArgs": "-t misc\\valid\\many_args.c",
       "workingDirectory": "C:\\Users\\Manuel\\OneDrive\\Development\\mcc\\mcc\\Test"
     },
     "stage1": {

--- a/mcc/Properties/launchSettings.json
+++ b/mcc/Properties/launchSettings.json
@@ -6,7 +6,7 @@
     },
     "debug": {
       "commandName": "Project",
-      "commandLineArgs": "-d misc\\valid\\many_args4.c",
+      "commandLineArgs": "-d stage_9\\valid\\mutual_recursion.c",
       "workingDirectory": "C:\\Users\\Manuel\\OneDrive\\Development\\mcc\\mcc\\Test"
     },
     "test": {

--- a/mcc/Test/misc/valid/many_args.c
+++ b/mcc/Test/misc/valid/many_args.c
@@ -1,0 +1,11 @@
+﻿int eleven(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine, int ten, int eleven)
+{
+    return one + two + three + four + five + six + seven + eight + nine + ten + eleven;
+}
+
+int main()
+{
+    int a = 5;
+    a = a + eleven(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    return a;
+}

--- a/mcc/Test/misc/valid/many_args2.c
+++ b/mcc/Test/misc/valid/many_args2.c
@@ -1,0 +1,9 @@
+﻿int eleven(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine, int ten, int eleven)
+{
+    return one + two + three + four + five + six + seven + eight + nine + ten + eleven;
+}
+
+int main()
+{
+    return eleven(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+}

--- a/mcc/Test/misc/valid/many_args3.c
+++ b/mcc/Test/misc/valid/many_args3.c
@@ -1,0 +1,9 @@
+﻿int eleven(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine, int ten, int eleven)
+{
+    return one + two + three + four + five + six + seven + eight + nine + ten + eleven;
+}
+
+int main()
+{
+    return eleven(1, eleven(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 3, 4, 5, 6, 7, 8, 9, 10, 11);
+}

--- a/mcc/Test/misc/valid/many_args4.c
+++ b/mcc/Test/misc/valid/many_args4.c
@@ -1,0 +1,9 @@
+﻿int eleven(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine, int ten, int eleven)
+{
+    return one + two + three + four + five + six + seven + eight + nine + ten + eleven;
+}
+
+int main()
+{
+    return eleven(1, 2 + eleven(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 3, 4, 5, 6, 7, 8, 9, 10, 11);
+}

--- a/mcc/Validator.cs
+++ b/mcc/Validator.cs
@@ -443,7 +443,7 @@ namespace mcc
                 else
                 {
                     // 8n+16 (16 bytes for return address and frame pointer, if normal function prologue is used)
-                    offset = baseOffset + i * pointerSize;
+                    offset = baseOffset + (i - argsInRegisters) * pointerSize;
                 }
 
                 string? parameter = function.Parameters[i];

--- a/mcc/mcc.csproj
+++ b/mcc/mcc.csproj
@@ -7,4 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="Test\misc\invalid\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
When calling a function, the arguments now get placed in the correct registers and on the stack according to calling conventions for the backends used.